### PR TITLE
Update path-finder version from 10.0.3 to 10.0.4

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,5 +1,5 @@
 cask "path-finder" do
-  version "10.0.4"
+  version "10.0.4,2093"
   sha256 "83982471dbe8c4c14ded70cb68336a85cb9a115a68f0a9e04029da6137f2c013"
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"

--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask "path-finder" do
-  version "10.0.3,2089"
-  sha256 "db3ec0c61ca85be9b94c4480b4344f5f3193d13bf3206c02f9111f9e2f804b34"
+  version "10.0.4"
+  sha256 "83982471dbe8c4c14ded70cb68336a85cb9a115a68f0a9e04029da6137f2c013"
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"
   name "Path Finder"


### PR DESCRIPTION
Change version to 10.0.4 and update sha256 to match download

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) 
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
